### PR TITLE
Lexicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ src/atproto/scratch.clj
 dev/
 config.edn
 *.db
+.dir-locals.el

--- a/deps.edn
+++ b/deps.edn
@@ -3,13 +3,13 @@
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.clojure/core.async {:mvn/version "1.8.711-beta1"}
         io.github.tonsky/clj-reload {:mvn/version "0.9.0"}
-        org.clojure/tools.namespace {:mvn/version "1.5.0"}
         com.cnuernber/charred {:mvn/version "1.034"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         org.java-websocket/Java-WebSocket {:mvn/version "1.6.0"}
         org.slf4j/slf4j-simple {:mvn/version "2.0.16"}
         com.nimbusds/nimbus-jose-jwt {:mvn/version "10.0.2"}
-        com.google.crypto.tink/tink {:mvn/version "1.7.0"}}
+        com.google.crypto.tink/tink {:mvn/version "1.7.0"}
+        mvxcvi/multiformats {:mvn/version "1.0.125"}}
  :aliases {:dev  {:extra-paths ["test" "dev"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}}
            :test {:extra-paths ["test"]

--- a/examples/statusphere/src/statusphere.clj
+++ b/examples/statusphere/src/statusphere.clj
@@ -203,7 +203,7 @@
 (defonce server (atom nil))
 
 (defn start-dev []
-  (let [env (read-env)]
+  (let [env (read-env "./config.edn")]
     (reset! server
             (run-jetty (handler env)
                        {:port (:port env)

--- a/src/atproto/at_uri.cljc
+++ b/src/atproto/at_uri.cljc
@@ -1,0 +1,53 @@
+(ns atproto.at-uri
+  "The AT URI scheme (at://) makes it easy to reference individual records in a specific repository,
+  identified by either DID or handle.
+
+  See https://atproto.com/specs/at-uri-scheme"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.http :as http]
+            [atproto.did :as did]
+            [atproto.handle :as handle]))
+
+(defn parse-uri
+  "Parse the string and return a map with: [scheme:][//authority][path][?query][#fragment].
+
+  Return nil if the string is not a well-formed URI."
+  [s]
+  #?(:clj (try
+            (let [uri (java.net.URI. s)]
+              (cond-> {:scheme (.getScheme uri)
+                       :authority (.getAuthority uri)}
+                (not (str/blank? (.getPath uri)))     (assoc :path (.getPath uri))
+                (not (str/blank? (.getQuery uri)))    (assoc :query (.getQuery uri))
+                (not (str/blank? (.getFragment uri))) (assoc :fragment (.getFragment uri))))
+            (catch Exception _))))
+
+;; todo: finish validation
+;; see https://github.com/bluesky-social/atproto/blob/main/packages/syntax/src/aturi_validation.ts
+(defn parse-at-uri
+  "Parse the at-uri string and return a map with :authority, :collection, and :rkey.
+
+  Return nil if the string is not a well-formed AT URI."
+  [s]
+  (when-let [{:keys [scheme authority path query fragment] :as m} (parse-uri s)]
+    (when (and (= scheme "at")
+               (or (s/valid? ::did/did authority)
+                   (s/valid? ::handle/handle authority)))
+      (let [[collection rkey & xs] (str/split path #"/")]
+        (when (empty? xs)
+          (cond-> {:authority authority}
+            collection (assoc :collection collection)
+            rkey (assoc :rkey rkey)))))))
+
+(s/def ::at-uri
+  (s/and string?
+         parse-at-uri))
+
+(comment
+
+  (require 'atproto.at-uri :reload)
+
+  (atproto.at-uri/parse-at-uri "at://example.com")
+
+  )

--- a/src/atproto/client.cljc
+++ b/src/atproto/client.cljc
@@ -68,23 +68,22 @@
   (and (::session/authenticated? session)
        (::session/did session)))
 
-(defn invoke
+(defn procedure
+  "Issue a procedure call with the given arguments."
   [client args & {:as opts}]
   (let [[cb val] (i/platform-async opts)]
     (if (and (::validate? client)
              (not (lexicon/valid-call? args)))
       (cb (lexicon/invalid-call args))
-      (if (lexicon/procedure? args)
-        (xrpc/procedure (:session client) args :callback cb)
-        (xrpc/query (:session client) args :callback cb)))
+      (xrpc/procedure (::session client) args :callback cb))
     val))
-
-(defn procedure
-  "Issue a procedure call with the given arguments."
-  [client args & {:as opts}]
-  (invoke client args opts))
 
 (defn query
   "Issue a query with the igven arguments."
   [client args & {:as opts}]
-  (invoke client args opts))
+  (let [[cb val] (i/platform-async opts)]
+    (if (and (::validate? client)
+             (not (lexicon/valid-call? args)))
+      (cb (lexicon/invalid-call args))
+      (xrpc/query (::session client) args :callback cb))
+    val))

--- a/src/atproto/data/json.cljc
+++ b/src/atproto/data/json.cljc
@@ -1,0 +1,118 @@
+(ns atproto.data.json
+  "Records and messages in atproto are stored, transmitted, encoded, and authenticated in a consistent way.
+
+  The core data model supports both binary (CBOR) and textual (JSON) representations.
+
+  See https://atproto.com/specs/data-model"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [multiformats.cid :as cid]
+            [clojure.math :as math]
+            ;; aliases for specs
+            [atproto.data.json.bytes    :as-alias bytes]
+            [atproto.data.json.cid-link :as-alias cid-link]
+            [atproto.data.json.object   :as-alias object]
+            [atproto.data.json.blob     :as-alias blob])
+  #?(:clj (:import [java.util Base64]
+                   [clojure.lang ExceptionInfo])))
+
+;; Limit integers because JS has only 53-bit precision
+(def js-max-integer (math/pow 2 53))
+
+;; Helpers
+
+(defn mime-type?
+  [s]
+  (re-matches #"^(\w+)\/((?:[\w\.-]+)(?:\+[\w\.-]+)?)(?:\s*;\s*([\S\.-=]+)?)?$"
+              s))
+
+(defn nsid?
+  [s]
+  (and (string? s)
+       (<= (count s) 317)
+       (re-matches #"^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z0-9]{0,62})?)$" s)))
+
+(defn cid?
+  [s]
+  (when (string? s)
+    (try
+      (cid/parse s)
+      true
+      (catch ExceptionInfo _
+        false))))
+
+(s/def ::type
+  ;; nonconforming: we don't need to tag the object and it causes some
+  ;; complications with the Lexicon specs that reuse those json types.
+  (s/nonconforming
+   (s/or :null     ::null
+         :boolean  ::boolean
+         :integer  ::integer
+         :string   ::string
+         :bytes    ::bytes
+         :cid-link ::cid-link
+         :array    ::array
+         :object   ::object
+         :blob     ::blob)))
+
+(s/def ::null nil?)
+
+(s/def ::boolean boolean?)
+
+(s/def ::integer
+  (s/conformer #(or (and (int? %)
+                         (<= (- js-max-integer) % (dec js-max-integer))
+                         (long %))
+                    ::s/invalid)))
+
+(s/def ::string string?)
+
+(s/def ::bytes
+  (s/keys :req-un [::bytes/$bytes]))
+
+(s/def ::bytes/$bytes
+  (s/conformer #(or #?(:clj (try
+                              (.decode (Base64/getDecoder) %)
+                              (catch Exception _)))
+                    ::s/invalid)))
+
+(s/def ::cid-link
+  (s/keys :req-un [::cid-link/$link]))
+
+(s/def ::cid-link/$link cid?)
+
+(s/def ::array
+  (s/coll-of ::type))
+
+(def reserved-field? #{:$type :$bytes :$link})
+(defn $field? [kwd] (str/starts-with? (name kwd) "$"))
+
+(s/def ::object
+  (s/and
+   (s/keys :opt-un [::object/$type])
+   (s/conformer
+    (fn [object]
+      ;; Cannot use reserved fields
+      (if (some reserved-field? (keys (dissoc object :$type)))
+        ::s/invalid
+        ;; Ignore $-fields for validation
+        (let [object-without-$fields (into {} (remove #($field? (key %)) object))
+              conformed-object (s/conform (s/map-of keyword? ::type)
+                                          object-without-$fields)]
+          (if (= ::s/invalid conformed-object)
+            ::s/invalid
+            ;; Put back the $fields in the object
+            (merge conformed-object
+                   (filter #($field? (key %)) object)))))))))
+
+(s/def ::object/$type
+  nsid?)
+
+(s/def ::blob
+  (s/keys :req-un [::blob/ref
+                   ::blob/mimeType
+                   ::blob/size]))
+
+(s/def ::blob/ref ::cid-link)
+(s/def ::blob/mimeType mime-type?)
+(s/def ::blob/size pos-int?)

--- a/src/atproto/did.cljc
+++ b/src/atproto/did.cljc
@@ -1,7 +1,5 @@
 (ns atproto.did
-  "Cross platform DID resolver.
-
-  Decentralized identifiers (DIDs) are persistent, long-term identifiers for atproto accounts.
+  "Decentralized identifiers (DIDs) are persistent, long-term identifiers for atproto accounts.
 
   DID = \"did:<method>:<method-specific-identifier>\"
 
@@ -13,24 +11,30 @@
             [clojure.spec.alpha :as s]
             [atproto.interceptor :as i]
             [atproto.http :as http]
-            [atproto.json :as json]))
+            [atproto.json :as json]
+            [atproto.did :as-alias did]))
 
-(defn- char-in
-  "Whether the character is between start and end, both inclusive."
-  [c start end]
-  (<= (int start) (int c) (int end)))
+;; Helpers
 
+(defn- char-in [c start end] (<= (int start) (int c) (int end)))
 (defn- digit? [c] (char-in c \0 \9))
 (defn- hex-char? [c] (or (digit? c) (char-in c \A \F)))
 (defn- method-char? [c] (or (digit? c) (char-in c \a \z)))
+(defn- base32-char? [c] (or (char-in c \a \z) (char-in c \2 \7)))
 
-(defn- method?
+;; Parsing & validation
+
+(s/def ::did/scheme #{"did"})
+
+(defn method?
   "Whether the string is a well-formed method name.
 
   See https://www.w3.org/TR/did-1.0/#did-syntax"
   [s]
   (and (not (str/blank? s))
        (every? method-char? s)))
+
+(s/def ::did/method (s/and string? method?))
 
 (defn msid?
   "Whether the string is a well-formed method-specific identifier.
@@ -65,8 +69,10 @@
       ;; Otherwise invalid
       :else false)))
 
+(s/def ::did/msid (s/and string? msid?))
+
 (defn parse
-  "Parse the input into a DID map with :scheme, :method, and :msid."
+  "Parse the input string into a map with :scheme, :method, and :msid."
   [input]
   (when-let [first-colon-idx (str/index-of input \:)]
     (when-let [second-colon-idx (str/index-of input \: (inc first-colon-idx))]
@@ -74,27 +80,25 @@
        :method (subs input (inc first-colon-idx) second-colon-idx)
        :msid (subs input (inc second-colon-idx))})))
 
-(s/def ::scheme #{"did"})
-(s/def ::method (s/and string? method?))
-(s/def ::msid (s/and string? msid?))
+(s/def ::did
+  (s/and string?
+         (s/conformer #(or (parse %) ::s/invalid))
+         (s/keys :req-un [::did/scheme ::did/method ::did/msid])))
 
-(s/def ::did-map (s/keys :req-un [::scheme ::method ::msid]))
+(defmulti method-spec
+  "Method-specific validation of the atproto DID."
+  :method)
 
-(s/def ::did (s/and string?
-                    (s/conformer #(or (parse %) ::s/invalid))
-                    ::did-map))
-
-(defmulti method-spec "Method-specific validation of the DID." :method)
-
-(s/def ::at-proto-did (s/and ::did
-                             (s/multi-spec method-spec :method)))
+(s/def ::at-did
+  (s/and ::did
+         (s/multi-spec method-spec :method)))
 
 (defn conform
   "Conform the input into a atproto DID string.
 
   Return :atproto.did/invalid if the input is not a valid atproto DID string."
   [input]
-  (let [atproto-did-map (s/conform ::at-proto-did input)]
+  (let [atproto-did-map (s/conform ::at-did input)]
     (if (= atproto-did-map ::s/invalid)
       ::invalid
       (let [{:keys [scheme method msid]} atproto-did-map]
@@ -123,8 +127,6 @@
     val))
 
 ;; PLC method
-
-(defn- base32-char? [c] (or (char-in c \a \z) (char-in c \2 \7)))
 
 (defmethod method-spec "plc"
   [_]
@@ -173,7 +175,7 @@
   (fn [{:keys [msid]}]
     (and
      ;; Ensure we can generate well formed URL from this DID
-     (s/valid? ::http/url (web-did-msid->url msid))
+     (s/valid? :http/url (web-did-msid->url msid))
      ;; Atproto does not allow path components in Web DIDs
      (not (str/index-of msid \:))
      ;; Atproto does not allow port numbers in Web DIDs, except for localhost

--- a/src/atproto/handle.cljc
+++ b/src/atproto/handle.cljc
@@ -1,7 +1,5 @@
 (ns atproto.handle
-  "Cross platform handle resolution.
-
-  Handles are human-friendly but less-permanent identifiers for atproto accounts.
+  "Handles are human-friendly but less-permanent identifiers for atproto accounts.
 
   See https://atproto.com/specs/handle."
   (:refer-clojure :exclude [resolve])

--- a/src/atproto/impl/jvm.clj
+++ b/src/atproto/impl/jvm.clj
@@ -87,7 +87,7 @@
                             (enumeration-seq)))})
     (catch NamingException ne
       {:error "DNS name not found"
-       :exception ne})))
+       :exception (Throwable->map ne)})))
 
 ;; To configure timeout and retries,
 ;; See https://download.oracle.com/otn_hosted_doc/jdeveloper/904preview/jdk14doc/docs/guide/jndi/jndi-dns.html

--- a/src/atproto/lexicon.cljc
+++ b/src/atproto/lexicon.cljc
@@ -53,7 +53,7 @@
   [args]
   (when-let [nsid (name (:op args))]
     (if (not (loaded-schema nsid))
-      (throw (ex-info (str "Unknown schema: " nsid)))
+      (throw (ex-info (str "Unknown schema: " nsid) {}))
       (= "procedure" (get-in @loaded-schemas [nsid :defs :main :type])))))
 
 ;; Validation

--- a/src/atproto/lexicon.cljc
+++ b/src/atproto/lexicon.cljc
@@ -1,0 +1,149 @@
+(ns atproto.lexicon
+  "Lexicon is a schema definition language used to describe atproto records,
+  HTTP endpoints (XRPC), and event stream messages.
+
+  See https://atproto.com/specs/lexicon"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.did :as did]
+            [atproto.nsid :as nsid]
+            [atproto.interceptor :as i]
+            [atproto.dns :as dns]
+            [atproto.xrpc :as xrpc]
+            [atproto.json :as json]
+            [atproto.lexicon.schema :as schema]
+            [atproto.lexicon.translator :refer [lex-uri->spec-key translate]]))
+
+;; TODO:
+;; - caching of DNS/lexicon
+
+(def lexicon-record-collection "com.atproto.lexicon.schema")
+
+(def loaded-schemas (atom {}))
+
+(defn loaded-schema
+  "The loaded schema with the given NSID."
+  [nsid]
+  (get @loaded-schemas nsid))
+
+(defn load-schema!
+  [schema]
+  (if (not (s/valid? ::schema/file schema))
+    (throw (ex-info "Invalid Lexicon schema."
+                    (s/explain-data ::schema/file schema)))
+    (let [spec-defs (translate schema)]
+      (eval `(do ~spec-defs))
+      (swap! loaded-schemas assoc (:id schema) schema)
+      :done)))
+
+(defn load-dir!
+  "Load all the Lexicon schemas from the directory."
+  [dir]
+  (->> dir
+       (file-seq)
+       (filter #(str/ends-with? (.getName %) ".json"))
+       (map #(json/read-str (slurp %)))
+       (map load-schema!)
+       (doall))
+  :done)
+
+;; Docuemntation
+
+(defn procedure?
+  [args]
+  (when-let [nsid (name (:op args))]
+    (if (not (loaded-schema nsid))
+      (throw (ex-info (str "Unknown schema: " nsid)))
+      (= "procedure" (get-in @loaded-schemas [nsid :defs :main :type])))))
+
+;; Validation
+
+(defn valid-call?
+  "Whether this is a valid procedure or subscription call."
+  [args]
+  (when-let [nsid (name (:op args))]
+    (if (not (loaded-schema nsid))
+      (throw (ex-info (str "Unknown schema: " nsid) args))
+      (s/valid? (lex-uri->spec-key nsid) args))))
+
+(defn invalid-call
+  "The error to return in case of an invalid call."
+  [args]
+  (let [nsid (name (:op args))]
+    (if (not (loaded-schema nsid))
+      {:error (str "Missing schema for " nsid)})
+    (merge {:error "Invalid call."}
+           (s/explain-data (lex-uri->spec-key nsid) args))))
+
+(defn valid?
+  "Whether the atproto data is valid.
+
+  Assume that the schemas have been loaded."
+  [lex-uri data]
+  (s/valid? (lex-uri->spec-key lex-uri)
+            data))
+
+;; Lexicon resolution
+
+(defn- fetch-lexicon
+  [{:keys [did pds rkey]} cb]
+  (xrpc/query {:atproto.session/service pds}
+              {:op :com.atproto.repo.getRecord
+               :params {:repo did
+                        :collection lexicon-record-collection
+                        :rkey rkey}}
+              :callback
+              (fn [{:keys [error] :as resp}]
+                (tap> resp)
+                (if error (cb resp) (cb (:value resp))))))
+
+(defn- nsid->did
+  "Resolve this NSID to a DID using DNS."
+  [nsid cb]
+  (let [{:keys [domain-authority]} (nsid/parse nsid)
+        hostname (->> (str/split domain-authority #"\.")
+                      (reverse)
+                      (into ["_lexicon"])
+                      (str/join "."))]
+    (println hostname)
+    (if (< 253 (count hostname))
+      (cb {:error (str "Cannot resolve nsid, hostname too long: " hostname)})
+      (i/execute {::i/request {:hostname hostname
+                               :type "txt"}
+                  ::i/queue [dns/interceptor]}
+                 :callback
+                 (fn [{:keys [error values] :as resp}]
+                   (if error
+                     (cb resp)
+                     (let [dids (->> values
+                                     (map #(some->> %
+                                                    (re-matches #"^did=(.+)$")
+                                                    (second)))
+                                     (remove nil?)
+                                     (seq))]
+                       (cond
+                         (empty? dids)      (cb {:error "Cannot resolve NSID. DID not found."})
+                         :else              (cb {:did (first dids)})))))))))
+
+(defn resolve-nsid
+  "Resolve the NSID into a Lexicon."
+  [nsid & {:as opts}]
+  (let [[cb val] (i/platform-async opts)]
+    (nsid->did nsid
+               (fn [{:keys [error did] :as resp}]
+                 (if error
+                   (cb resp)
+                   (did/resolve did
+                                :callback
+                                (fn [{:keys [error did doc] :as resp}]
+                                  (if error
+                                    (cb resp)
+                                    (if-let [pds (did/pds doc)]
+                                      (fetch-lexicon {:did did
+                                                      :pds pds
+                                                      :rkey nsid} cb)
+                                      (cb {:error "DID doc is missing the PDS url."
+                                           :nsid nsid
+                                           :did did
+                                           :doc doc}))))))))
+    val))

--- a/src/atproto/lexicon/schema.cljc
+++ b/src/atproto/lexicon/schema.cljc
@@ -1,0 +1,286 @@
+(ns atproto.lexicon.schema
+  "Clojure specs to validate a Lexicon schema.
+
+  See https://atproto.com/specs/lexicon"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.lexicon.specs :as lexicon]
+            ;; Aliases to use shorter spec keys
+            [atproto.lexicon.schema.file              :as-alias file]
+            [atproto.lexicon.schema.type-def          :as-alias type-def]
+            [atproto.lexicon.schema.error             :as-alias error]
+            [atproto.lexicon.schema.body              :as-alias body]
+            [atproto.lexicon.schema.message           :as-alias message]
+            [atproto.lexicon.schema.type.null         :as-alias null]
+            [atproto.lexicon.schema.type.boolean      :as-alias boolean]
+            [atproto.lexicon.schema.type.integer      :as-alias integer]
+            [atproto.lexicon.schema.type.string       :as-alias string]
+            [atproto.lexicon.schema.type.bytes        :as-alias bytes]
+            [atproto.lexicon.schema.type.cid-link     :as-alias cid-link]
+            [atproto.lexicon.schema.type.array        :as-alias array]
+            [atproto.lexicon.schema.type.object       :as-alias object]
+            [atproto.lexicon.schema.type.blob         :as-alias blob]
+            [atproto.lexicon.schema.type.params       :as-alias params]
+            [atproto.lexicon.schema.type.token        :as-alias token]
+            [atproto.lexicon.schema.type.ref          :as-alias ref]
+            [atproto.lexicon.schema.type.union        :as-alias union]
+            [atproto.lexicon.schema.type.unknown      :as-alias unkown]
+            [atproto.lexicon.schema.type.record       :as-alias record]
+            [atproto.lexicon.schema.type.query        :as-alias query]
+            [atproto.lexicon.schema.type.procedure    :as-alias procedure]
+            [atproto.lexicon.schema.type.subscription :as-alias subscription]))
+
+;; -----------------------------------------------------------------------------
+;; Schema
+;; -----------------------------------------------------------------------------
+
+(defn- valid-defs?
+  "Wether the defs property in a lexicon schema is valid.
+
+  - A schema can have at most one definition with one of the primary types.
+  - Primary types should always have the name main."
+  [defs]
+  (let [primary-type-defs (filter (fn [[name def]]
+                                    (= :primary (first def)))
+                                  defs)]
+    (or (zero? (count primary-type-defs))
+        (and (= 1 (count primary-type-defs))
+             (= :main (ffirst primary-type-defs))))))
+
+(s/def ::file
+  (s/keys :req-un [::file/lexicon
+                   ::file/id
+                   ::file/defs]
+          :opt-un [::file/$type
+                   ::file/revision
+                   ::file/description]))
+
+(s/def ::file/lexicon #{1})
+(s/def ::file/$type #{"com.atproto.lexicon.schema"})
+(s/def ::file/id ::lexicon/nsid)
+(s/def ::file/revision int?)
+(s/def ::file/description string?)
+(s/def ::file/defs (s/and (s/map-of keyword?
+                                    (s/or :primary ::primary-type-def
+                                          :field   ::field-type-def))
+                          valid-defs?))
+
+;; shared properties across all type definitions
+(s/def ::type-def/type string?)
+
+(s/def ::type-def/description string?)
+
+(defn field-type-def
+  "Return a spec expecting a field type definition of the given type(s)."
+  [& types]
+  (s/and #(contains? (set types) (:type %))
+         ::field-type-def))
+
+;; -----------------------------------------------------------------------------
+;; Field Type Definition
+;; -----------------------------------------------------------------------------
+
+(defmulti field-type-spec :type)
+
+(s/def ::field-type-def
+  (s/and (s/keys :req-un [::type-def/type]
+                 :opt-un [::type-def/description])
+         (s/multi-spec field-type-spec :type)))
+
+(defmethod field-type-spec "null" [_]
+  any?)
+
+(defmethod field-type-spec "boolean" [_]
+  (s/keys :opt-un [::boolean/default
+                   ::boolean/const]))
+
+(s/def ::boolean/default boolean?)
+(s/def ::boolean/const boolean?)
+
+(defmethod field-type-spec "integer" [_]
+  (s/keys :opt-un [::integer/minimum
+                   ::integer/maximum
+                   ::integer/enum
+                   ::integer/default
+                   ::integer/const]))
+
+(s/def ::integer/minimum int?)
+(s/def ::integer/maximum int?)
+(s/def ::integer/enum (s/coll-of int?))
+(s/def ::integer/default int?)
+(s/def ::integer/const int?)
+
+(defmethod field-type-spec "string" [_]
+  (s/keys :opt-un [::string/format
+                   ::string/maxLength
+                   ::string/minLength
+                   ::string/maxGraphemes
+                   ::string/minGraphemes
+                   ::string/knownValues
+                   ::string/enum
+                   ::string/default
+                   ::string/const]))
+
+(s/def ::string/format #{"at-identifier" "at-uri" "cid" "datetime" "did"
+                         "handle" "nsid" "tid" "record-key" "uri" "language"})
+(s/def ::string/maxLength int?)
+(s/def ::string/minLength int?)
+(s/def ::string/maxGraphemes int?)
+(s/def ::string/minGraphemes int?)
+(s/def ::string/knownValues (s/coll-of string?))
+(s/def ::string/enum (s/coll-of string?))
+(s/def ::string/default string?)
+(s/def ::string/const string?)
+
+(defmethod field-type-spec "bytes" [_]
+  (s/keys :opt-un [::bytes/minLength
+                   ::bytes/maxLength]))
+
+(s/def ::bytes/minLength int?)
+(s/def ::bytes/maxLength int?)
+
+(defmethod field-type-spec "cid-link" [_]
+  any?)
+
+(defmethod field-type-spec "blob" [_]
+  (s/keys :opt-un [::blob/accept
+                   ::blob/maxSize]))
+
+(s/def ::blob/accept (s/coll-of ::lexicon/mime-type-pattern))
+(s/def ::blob/maxSize int?)
+
+(defmethod field-type-spec "array" [_]
+  (s/keys :req-un [::array/items]
+          :opt-un [::array/minLength
+                   ::array/maxLength]))
+
+(s/def ::array/items ::field-type-def)
+(s/def ::array/minLength int?)
+(s/def ::array/maxLength int?)
+
+(defmethod field-type-spec "object" [_]
+  (s/keys :req-un [::object/properties]
+          :opt-un [::object/required
+                   ::object/nullable]))
+
+(s/def ::object/properties (s/map-of keyword? ::field-type-def))
+(s/def ::object/required (s/coll-of string?))
+(s/def ::object/nullable (s/coll-of string?))
+
+(defmethod field-type-spec "params" [_]
+  (s/keys :req-un [::params/properties]
+          :opt-un [::params/required]))
+
+(s/def ::params/properties
+  (s/map-of keyword?
+            (field-type-def "boolean" "integer" "string" "unknown" "array")))
+
+(s/def ::params/required
+  (s/coll-of string?))
+
+(defmethod field-type-spec "token" [_]
+  any?)
+
+(defmethod field-type-spec "ref" [_]
+  (s/keys :req-un [::ref/ref]))
+
+(s/def ::ref/ref
+  (s/or :local-ref (s/conformer
+                    (fn [s]
+                      (if (str/starts-with? s "#")
+                        (subs s 1)
+                        ::s/invalid)))
+        :global-ref (s/conformer
+                     (fn [s]
+                       (let [[nsid name] (str/split s #"#")]
+                         (if (s/valid? ::lexicon/nsid nsid)
+                           s
+                           ::s/invalid))))))
+
+(defmethod field-type-spec "union" [_]
+  (s/and
+   (s/keys :opt-un [::union/refs
+                    ::union/closed])
+   ;; refs is only optional if closed=false
+   (fn [{:keys [refs closed]}]
+     (or (not (empty? refs))
+         (not closed)))))
+
+(s/def ::union/refs (s/coll-of ::ref/ref))
+
+(s/def ::union/closed boolean?)
+
+(defmethod field-type-spec "unknown" [_]
+  any?)
+
+;; -----------------------------------------------------------------------------
+;; Primary Type Definitions
+;; -----------------------------------------------------------------------------
+
+(s/def ::error
+  (s/keys :req-un [::error/name]
+          :opt-un [::error/description]))
+
+(s/def ::error/name (s/and string? #(not (re-matches #"\s" %))))
+(s/def ::error/description string?)
+
+(s/def ::body
+  (s/keys :req-un [::body/encoding]
+          :opt-un [::body/description
+                   ::body/schema]))
+
+(s/def ::body/encoding ::lexicon/mime-type-pattern)
+(s/def ::body/description string?)
+(s/def ::body/schema (s/or :object (field-type-def "object")
+                           :ref    (field-type-def "ref")
+                           :union  (field-type-def "union")))
+
+(defmulti primary-type-spec :type)
+
+(s/def ::primary-type-def
+  (s/and (s/keys :req-un [::type-def/type]
+                 :opt-un [::type-def/description])
+         (s/multi-spec primary-type-spec :type)))
+
+(defmethod primary-type-spec "record" [_]
+  (s/keys :req-un [::record/key
+                   ::record/record]))
+
+(s/def ::record/record (field-type-def "object"))
+(s/def ::record/key
+  (s/or :tid     #{"tid"}
+        :nsid    #{"nsid"}
+        :literal #(let [[_ value] (re-matches #"literal:(.+)$" %)]
+                    (or value ::s/invalid))
+        :any     #{"any"}))
+
+(defmethod primary-type-spec "query" [_]
+  (s/keys :opt-un [::query/parameters
+                   ::query/output
+                   ::query/errors]))
+
+(s/def ::query/parameters (field-type-def "params"))
+(s/def ::query/output ::body)
+(s/def ::query/errors (s/coll-of ::error))
+
+(defmethod primary-type-spec "procedure" [_]
+  (s/keys :opt-un [::procedure/parameters
+                   ::procedure/output
+                   ::procedure/input
+                   ::procedure/errors]))
+
+(s/def ::procedure/parameters (field-type-def "params"))
+(s/def ::procedure/output ::body)
+(s/def ::procedure/input ::body)
+(s/def ::procedure/errors (s/coll-of ::error))
+
+(defmethod primary-type-spec "subscription" [_]
+  (s/keys :opt-un [::subscription/parameters
+                   ::subscription/message
+                   ::subscription/errors]))
+
+(s/def ::subscription/parameters (field-type-def "params"))
+(s/def ::subscription/message (s/keys :req-un [::message/schema]
+                                      :opt-un [::message/description]))
+(s/def ::message/schema (field-type-def "union"))
+(s/def ::message/description string?)

--- a/src/atproto/lexicon/specs.cljc
+++ b/src/atproto/lexicon/specs.cljc
@@ -1,0 +1,94 @@
+(ns atproto.lexicon.specs
+  "Primitive Lexicon specs used by `atproto.lexicon.schema` and `atproto.lexicon.generator`."
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]
+            [atproto.data.json :as json])
+  #?(:clj (:import [java.time Instant]
+                   [java.util Base64])))
+
+(defn count-graphemes
+  [s]
+  #?(:clj (.codePointCount s 0 (count s))))
+
+(s/def ::did
+  (s/and string?
+         #(<= (count %) 2048)
+         #(re-matches #"^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$" %)
+         (s/conformer str/lower-case)))
+
+(s/def ::handle
+  (s/and string?
+         #(<= (count %) 253)
+         #(re-matches #"^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$" %)))
+
+(s/def ::at-identifier
+  (s/or :handle ::handle
+        :did ::did))
+
+(s/def ::nsid
+  (s/and string?
+         #(<= (count %) 317)
+         #(re-matches #"^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z0-9]{0,62})?)$" %)))
+
+(s/def ::record-key
+  (s/and string?
+         #(<= 1 (count %) 512)
+         #(re-matches #"^[a-zA-Z0-9_~.:-]{1,512}$" %)
+         #(not (#{"." ".."} %))))
+
+(s/def ::tid
+  (s/and string?
+         #(= 13 (count %))
+         #(re-matches #"^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$" %)))
+
+(s/def ::cid
+  json/cid?)
+
+;; todo: valid handle or did in authority
+;;       valid nsid in collection (optional)
+;;       make regexp work with ClojureScript. In Java, inside a character class, the escape character (\) must be escaped.
+(s/def ::at-uri
+  (s/and string?
+         #(< (count %) (* 8 1024))
+         #(re-matches #"^at:\/\/([a-zA-Z0-9._:%-]+)(\/([a-zA-Z0-9-.]+)(\/([a-zA-Z0-9._~:@!$&%')(*+,;=-]+))?)?(#(\/[a-zA-Z0-9._~:@!$&%')(*+,;=\\-[\\]/\\]*))?$" %)))
+
+;; todo: support `1985-04-12T23:20:50.12345678912345Z`?
+(s/def ::datetime
+  #?(:clj #(try (Instant/parse %) (catch Exception _))))
+
+(s/def ::uri
+  #?(:clj #(try (java.net.URI. %) (catch Exception _))))
+
+(s/def ::language
+  #?(:clj #(try (-> (java.util.Locale$Builder.) (.setLanguageTag %)) (catch Exception _))))
+
+(s/def ::mime-type
+  (s/conformer
+   #(or (when-let [[_ type subtype parameter] (re-matches #"^(\w+)\/((?:[\w\.-]+)(?:\+[\w\.-]+)?)(?:\s*;\s*([\S\.-=]+)?)?$" %)]
+          (cond-> {:type type
+                   :subtype subtype}
+            (not (str/blank? parameter)) (assoc :parameter parameter)))
+        ::s/invalid)))
+
+;; todo: support more complex glob patterns?
+(s/def ::mime-type-pattern
+  (s/or :any     #{"*/*"}
+        :type    (s/conformer #(or (when-let [[_ type] (re-matches #"^(\w+)\/\*" %)]
+                                     {:type type})
+                                   ::s/invalid))
+        :subtype ::mime-type))
+
+(defn mime-type-pattern->spec
+  "Translate a MIME type pattern into a Spec form and return it."
+  [[pattern-type pattern]]
+  (let [spec (case pattern-type
+               :any     'any?
+               :type    `#(= ~pattern (select-keys % [:type]))
+               :subtype `#(= ~pattern (select-keys % [:type :subtype])))]
+    `(s/and ::mime-type
+            ~spec)))
+
+(defn accept-mime-type?
+  [accept mime-type]
+  (some #(s/valid? (mime-type-pattern->spec %) mime-type)
+        accept))

--- a/src/atproto/lexicon/translator.cljc
+++ b/src/atproto/lexicon/translator.cljc
@@ -1,0 +1,284 @@
+(ns atproto.lexicon.translator
+  "Translate Lexicon schemas to Clojure spec forms."
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.data.json :as json]
+            [atproto.lexicon.specs :as lexicon]
+            [atproto.lexicon.schema :as schema]))
+
+;; TODO:
+;; - should conform set the default value? (it needs to be on the container)
+;; - test data generators for specs
+
+(defn lex-uri->spec-key
+  "The Spec key corresponding to this Lexicon schema URI."
+  [s]
+  (let [[nsid type-name] (str/split s #"#")]
+    (if type-name
+      (keyword nsid type-name)
+      (let [idx (str/last-index-of nsid \.)]
+        (keyword (subs nsid 0 idx)
+                 (subs nsid (inc idx)))))))
+
+(defn- spec-key
+  "The spec key in the current context."
+  [ctx]
+  (lex-uri->spec-key (:spec-ns ctx)))
+
+(defn- nest
+  "Add the type name to the current context, if not 'main'."
+  [ctx type-name]
+  (if (= "main" type-name)
+    ctx
+    (update ctx :spec-ns str "." type-name)))
+
+(defn- add-spec!
+  "Add the spec definition to the context."
+  [ctx spec]
+  (swap! (:def-specs ctx) conj `(s/def ~(spec-key ctx) ~spec)))
+
+(defmulti ^:private field-type-def->spec
+  "Translate the field type definition into a spec form and return it.
+
+  Implementations can add 'sub specs' in the context as needed."
+  (fn [ctx type-def] (:type type-def)))
+
+(defmulti ^:private translate-primary-type-def!
+  "Translate the Lexicon Primary Type Definition into spec forms and add them to the context."
+  (fn [ctx primary-type-def] (:type primary-type-def)))
+
+(defn translate
+  "Translate the Lexicon file into Clojure spec forms and return them as a seq."
+  [{:keys [id] :as file}]
+  (let [conformed-file (s/conform ::schema/file file)]
+    (if (= ::s/invalid conformed-file)
+      (throw (ex-info "Invalid Lexicon schema file." {:file file}))
+      (->> (reduce (fn [ctx [type-key [type type-def]]]
+                     (let [ctx (nest ctx (name type-key))]
+                       (case type
+                         :primary (translate-primary-type-def! ctx type-def)
+                         :field   (add-spec! ctx (field-type-def->spec ctx type-def))))
+                     ctx)
+                   {:nsid id
+                    :spec-ns id
+                    :def-specs (atom [])}
+                   (:defs conformed-file))
+           :def-specs
+           deref))))
+
+(defn- rkey-type->spec
+  "Translate the record key type into a spec form and return it."
+  [[rkey-type rkey-value]]
+  (case rkey-type
+    :tid     ::lexicon/tid
+    :nsid    ::lexicon/nsid
+    :literal #{rkey-value}
+    :any     ::lexicon/record-key))
+
+(defmethod translate-primary-type-def! "record"
+  [{:keys [spec-ns] :as ctx} {:keys [key record]}]
+  (let [rkey-spec-key (let [ctx (nest ctx "key")]
+                        (add-spec! ctx (rkey-type->spec key))
+                        (spec-key ctx))]
+    (add-spec! ctx `(s/and
+                     (s/keys :req-un [~rkey-spec-key])
+                     ~(field-type-def->spec ctx record)))))
+
+(defn- translate-http-body-schema-def!
+  "Translate a HTTP body schema into a Clojure spec form and add it to the context."
+  [ctx {:keys [encoding schema]}]
+  (let [spec-keys (cond-> []
+                    encoding
+                    (conj (let [ctx (nest ctx "encoding")]
+                            (add-spec! ctx (lexicon/mime-type-pattern->spec encoding))
+                            (spec-key ctx)))
+                    schema
+                    (conj (let [ctx (nest ctx "body")]
+                            (add-spec! ctx (field-type-def->spec ctx (second schema)))
+                            (spec-key ctx))))]
+    (add-spec! ctx
+               `(s/keys :req-un [~@spec-keys]))))
+
+(defn translate-primary-type-field!
+  [ctx [field-name field-def]]
+  (case field-name
+    :parameters
+    (let [ctx (nest ctx "params")]
+      (add-spec! ctx (field-type-def->spec ctx field-def))
+      (spec-key ctx))
+
+    (:input :output)
+    (let [ctx (nest ctx (name field-name))]
+      (translate-http-body-schema-def! ctx field-def)
+      (spec-key ctx))
+
+    :errors
+    (let [ctx (nest ctx "error")]
+      (add-spec! ctx (set field-def))
+      (spec-key ctx))
+
+    :message
+    (let [ctx (nest ctx "message")]
+      (add-spec! ctx (field-type-def->spec ctx (:schema field-def)))
+      (spec-key ctx))))
+
+;; shared implementation for query/procedure/subscription
+(defmethod translate-primary-type-def! :default
+  [ctx type-def]
+  (let [spec-keys (mapv #(translate-primary-type-field! ctx %)
+                        (select-keys type-def
+                                     [:parameters :input :output :errors :message]))]
+    (add-spec! ctx
+               `(s/keys :opt-un [~@spec-keys]))))
+
+;; Field Type Definitions
+
+(defmethod field-type-def->spec "null"
+  [ctx def]
+  ::json/null)
+
+(defmethod field-type-def->spec "boolean"
+  [ctx {:keys [default const]}]
+  (let [specs (cond-> [::json/boolean]
+                const (conj `#{~const}))]
+    `(s/and ~@specs)))
+
+(defmethod field-type-def->spec "integer"
+  [ctx {:keys [minimum maximum enum default const]}]
+  (let [specs (cond-> [::json/integer]
+                minimum  (conj `#(<= ~minimum %))
+                maximum  (conj `#(<= % ~maximum))
+                enum     (conj `#{~@enum})
+                const    (conj `#{~const}))]
+    `(s/and ~@specs)))
+
+(defmethod field-type-def->spec "string"
+  [ctx {:keys [format maxLength minLength maxGraphemes minGraphemes
+               knownValues enum default const]}]
+  (let [specs (cond-> [::json/string]
+                format       (conj (keyword "atproto.lexicon.specs" format))
+                maxLength    (conj `#(<= (count %) ~maxLength))
+                minLength    (conj `#(<= ~minLength (count %)))
+                maxGraphemes (conj `#(<= (lexicon/count-graphemes %) ~maxGraphemes))
+                minGraphemes (conj `#(<= ~minGraphemes (~lexicon/count-graphemes %)))
+                enum         (conj `#{~@enum})
+                const        (conj `#{~const}))]
+    `(s/and ~@specs)))
+
+(defmethod field-type-def->spec "bytes"
+  [ctx {:keys [minLength maxLength]}]
+  (let [specs (cond-> [::json/bytes]
+                minLength (conj `#(<= ~minLength (count %)))
+                maxLength (conj `#(<= (count %) ~maxLength)))]
+    `(s/and ~@specs)))
+
+(defmethod field-type-def->spec "cid-link"
+  [ctx def]
+  `::json/cid-link)
+
+(defmethod field-type-def->spec "blob"
+  [ctx {:keys [accept maxSize]}]
+  (let [specs (cond-> [::json/blob]
+                accept  (conj `#(lexicon/accept-mime-type? ~accept (:mimeType %)))
+                maxSize (conj `#(<= (:size %) ~maxSize)))]
+    `(s/and ~@specs)))
+
+(defmethod field-type-def->spec "array"
+  [ctx {:keys [items minLength maxLength]}]
+  (let [items-spec (field-type-def->spec ctx items)
+        opts (cond-> {}
+               minLength (assoc :min-count minLength)
+               maxLength (assoc :max-count maxLength))]
+    `(s/and ::json/array
+            (s/coll-of ~items-spec ~opts))))
+
+(defmethod field-type-def->spec "object"
+  [ctx {:keys [properties required nullable]}]
+  (let [required? (set (map keyword required))
+        nullable? (set (map keyword nullable))
+        keys (reduce (fn [keys [prop-key prop-type]]
+                       (let [ctx (nest ctx (name prop-key))
+                             spec (let [spec (field-type-def->spec ctx prop-type)]
+                                    (if (nullable? prop-key)
+                                      `(s/nilable ~spec)
+                                      spec))]
+                         (add-spec! ctx spec)
+                         (update keys
+                                 (if (required? prop-key) :required :optional)
+                                 conj
+                                 (spec-key ctx))))
+                     {:required []
+                      :optional []}
+                     properties)]
+    `(s/and ::json/object
+            (s/keys :req-un ~(:required keys)
+                    :opt-un ~(:optional keys)))))
+
+(defmethod field-type-def->spec "params"
+  [ctx {:keys [required properties]}]
+  (let [required? (set (map keyword required))
+        keys (reduce (fn [keys [prop-key prop-type]]
+                       (let [ctx (nest ctx (name prop-key))
+                             spec (field-type-def->spec ctx prop-type)]
+                         (add-spec! ctx spec)
+                         (update keys
+                                 (if (required? prop-key) :required :optional)
+                                 conj
+                                 (spec-key ctx))))
+                     {:required []
+                      :optional []}
+                     properties)]
+    `(s/and ::json/object
+            (s/keys :req-un ~(:required keys)
+                    :opt-un ~(:optional keys)))))
+
+(defmethod field-type-def->spec "token"
+  [ctx _]
+  `(constantly false))
+
+(defn resolve-ref
+  "Resolve the Lexicon reference."
+  [ctx [ref-type ref]]
+  (case ref-type
+    :local-ref  (str (:nsid ctx) "#" ref)
+    :global-ref ref))
+
+(defmethod field-type-def->spec "ref"
+  [ctx {:keys [ref]}]
+  ;; We could simply return the spec key here but that would
+  ;; require toposorting the specs before defining them.
+  ;; I'm not even sure there can't be any cycle in the Lexicon schemas.
+  ;; Downside: we only detect missing specs at validation time.
+  (let [spec-key (lex-uri->spec-key (resolve-ref ctx ref))]
+    `(s/nonconforming
+      (s/or ~spec-key ~spec-key))))
+
+(defmulti object-spec
+  "Return the spec for an object at validation time based on its $type field."
+  (constantly nil))
+
+(defmethod object-spec :default
+  [v]
+  (if (:$type v)
+    (lex-uri->spec-key (:$type v))
+    any?))
+
+(defmethod field-type-def->spec "union"
+  [ctx {:keys [refs closed]}]
+  (let [spec (if (not (seq refs))
+               ;; closed is false by definition
+               (s/multi-spec object-spec identity)
+               (let [branches (cond-> (->> refs
+                                           (map #(lex-uri->spec-key (resolve-ref ctx %)))
+                                           (mapcat #(repeat 2 %)))
+                                (not closed)
+                                (concat `[:unknown (s/multi-spec object-spec identity)]))]
+                 `(s/or ~@branches)))]
+    `(s/and ::json/object
+            #(contains? % :$type)
+            ~spec)))
+
+(defmethod field-type-def->spec "unknown"
+  [ctx _]
+  `(s/and ::json/object
+          (s/multi-spec object-spec identity)))

--- a/src/atproto/nsid.cljc
+++ b/src/atproto/nsid.cljc
@@ -1,0 +1,16 @@
+(ns atproto.nsid
+  "Namespaced Identifiers (NSIDs) are used to reference Lexicon schemas for records, XRPC endpoints, and more.
+
+  See https://atproto.com/specs/nsid"
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [atproto.interceptor :as i]
+            [atproto.dns :as dns]
+            [atproto.did :as did]))
+
+(defn parse
+  "Parse the input string into a map with :domain-authority and :name."
+  [nsid]
+  (when-let [sep (str/last-index-of nsid \.)]
+    {:authority (subs nsid 0 sep)
+     :name (subs nsid sep)}))

--- a/src/atproto/session.cljc
+++ b/src/atproto/session.cljc
@@ -14,7 +14,7 @@
 (s/def ::service ::http/url)
 
 ;; The DID of the authenticated user.
-(s/def ::did ::did/did)
+(s/def ::did ::did/at-did)
 
 ;; The handle of the authenticated user, if any.
 (s/def ::handle ::handle/handle)


### PR DESCRIPTION
1. Translate Lexicon schema files to Clojure specs.
2. Users can decide whether to generate Clojure files to include in their client or eval at load time.
3. Resolve Lexicon from NSID.
4. Add flag to client to validate args to proc and query. Requires schema to be loaded first.